### PR TITLE
update  overview, quickstart and transcation-group documents (zh-cn)

### DIFF
--- a/docs/en-us/user/quickstart.md
+++ b/docs/en-us/user/quickstart.md
@@ -198,7 +198,7 @@ CREATE TABLE `account_tbl` (
 Usage: sh seata-server.sh(for linux and mac) or cmd seata-server.bat(for windows) [options]
   Options:
     --host, -h
-      The host to bind.
+      The address is expose to registration center and other service can access seata-server via this ip.
       Default: 0.0.0.0
     --port, -p
       The port to listen.

--- a/docs/zh-cn/overview/what-is-seata.md
+++ b/docs/zh-cn/overview/what-is-seata.md
@@ -8,6 +8,10 @@ description: Seata 是一款开源的分布式事务解决方案，致力于提�
 
 
 Seata 是一款开源的分布式事务解决方案，致力于提供高性能和简单易用的分布式事务服务。Seata 将为用户提供了 AT、TCC、SAGA 和 XA 事务模式，为用户打造一站式的分布式解决方案。
+![image](https://user-images.githubusercontent.com/68344696/145942191-7a2d469f-94c8-4cd2-8c7e-46ad75683636.png)
+
+
+
 
 # AT 模式
 

--- a/docs/zh-cn/user/quickstart.md
+++ b/docs/zh-cn/user/quickstart.md
@@ -197,7 +197,7 @@ CREATE TABLE `account_tbl` (
 Usage: sh seata-server.sh(for linux and mac) or cmd seata-server.bat(for windows) [options]
   Options:
     --host, -h
-      The host to bind.
+      The address is expose to registration center and other service can access seata-server via this ip
       Default: 0.0.0.0
     --port, -p
       The port to listen.

--- a/docs/zh-cn/user/txgroup/transaction-group.md
+++ b/docs/zh-cn/user/txgroup/transaction-group.md
@@ -107,21 +107,21 @@ config {
 - 配置中心配置项
 
 
-  在Seata Server的安装目录conf下README-zh.md或README.md文件中介绍了Seata需要的常见脚本链接，包括三类：客户端的配置和SQL、SeataServer端部署所需SQL和脚本、配置中心的初始化配置项脚本。
-  其中在script/config-center下有文件和目录如下
+  在Seata Server的安装目录conf下`README-zh.md`或`README.md`文件中介绍了Seata需要的常见脚本URL链接，包括三类：客户端的配置和SQL、SeataServer端部署所需SQL和脚本、配置中心配置项模板和脚本。
+  其中在script/config-center下有文件和目录如下:
      - README.md     使用帮助
-     - config.txt    配置项明细（包含Server和Client）
-     - nacos/        推送至nacos的脚本 
-     - apollo/
-     - consul/
-     - etcd3/
-     - zk/
+     - config.txt    配置项模板（包含Server和Client）
+     - nacos/        推至nacos的python和shell脚本 
+     - apollo/       推至apollo的shell脚本
+     - consul/       推至consul的shell脚本
+     - etcd3/        推至etcd3的shell脚本
+     - zk/           推至zookeeper的shell脚本
   
-  config.txt中的配置项需要根据实际情况选择和修改。
-  然后配置到配置中心：即可参照README.md使用帮助通过脚本推送至配置中心。也将config.txt中的内容人工拷贝至配置中心（例如通过Nacas的Web页面）
+  config.txt模板中的配置项，需要根据实际情况筛选和修改。
+  然后配置到配置中心：即可参照README.md使用帮助通过脚本推送至配置中心。也将config.txt中的内容人工拷贝至配置中心（例如通过nacos配置中心的Web页面）。  配置完毕后需要检查结果是否正确。
 
 - 注册至注册中心
- 启动seata-server注册至nacos，查看nacos控制台服务列表确认是否成功  
+ 启动seata-server注册至nacos注册中心，查看nacos控制台服务列表确认是否成功  
 
 #### Client端
 ```

--- a/docs/zh-cn/user/txgroup/transaction-group.md
+++ b/docs/zh-cn/user/txgroup/transaction-group.md
@@ -6,24 +6,25 @@ description: Seata 事务分组。
 
 # 事务分组专题
 
-### 事务分组涉及的概念？
+### 事务分组是什么？
 - 事务分组：seata的资源逻辑，可以按微服务的需要对事务进行逻辑上分组，每组取一个名字。可以在应用程序（客户端）中通过属性tx-service-group定义事务分组。
 - 集群：seata-server服务端一个或多个节点组成的集群cluster。 应用程序（客户端）使用时需要指定事务逻辑分组与Seata服务端集群的映射关系。
-
-### 通过事务分组如何找到后端集群？
-1. 首先程序中配置了事务分组（GlobalTransactionScanner 构造方法的txServiceGroup参数， 在Spring中配置项为：seata.tx-service-group）
-2. 程序会通过用户配置的配置中心去寻找service.vgroupMapping （在Spring中配置项为：seata.service.vgroup-mapping.事务分组名=集群名， 其中集群名需要与Seata服务端配置的cluster保持一致）
-.[*事务分组配置项*]，取得配置项的值就是TC集群的名称
-3. 拿到集群名称程序通过一定的前后缀+集群名称去构造服务名，各配置中心的服务名实现不同
-4. 拿到服务名去相应的注册中心去拉取相应服务名的服务列表，获得后端真实的TC服务列表
+### 事务分组如何找到后端Seata集群？
+1. 首先应用程序（客户端）中配置了事务分组（GlobalTransactionScanner 构造方法的txServiceGroup参数）。若应用程序是SpringBoot则通过seata.tx-service-group 配置
+2. 应用程序（客户端）会通过用户配置的配置中心去寻找service.vgroupMapping
+.[*事务分组配置项*]，取得配置项的值就是TC集群的名称。若应用程序是SpringBoot则通过seata.service.vgroup-mapping.事务分组名=集群名称 配置
+3. 拿到集群名称程序通过一定的前后缀+集群名称去构造服务名，各配置中心的服务名实现不同（前提是Seata-Server已经完成服务注册，且Seata-Server向注册中心报告cluster名与应用程序（客户端）配置的集群名称一致）
+4. 拿到服务名去相应的注册中心去拉取相应服务名的服务列表，获得后端真实的TC服务列表（即Seata-Server集群节点列表）
 
 ### 为什么这么设计，不直接取服务名？
 这里多了一层获取事务分组到映射集群的配置。这样设计后，事务分组可以作为资源的逻辑隔离单位，出现某集群故障时可以快速failover，只切换对应分组，可以把故障缩减到服务级别，但前提也是你有足够server集群。
 
 ## 事务分组使用案例
-seata注册、配置中心分为两类，内置file、第三方注册（配置）中心如nacos等等，注册中心和配置中心之间没有约束，可各自使用不同类型。
+seata注册、配置中心分为两大类：
+- 内置file
+- 第三方注册（配置）中心。如nacos等等，注册中心和配置中心之间没有约束，可各自使用不同类型。
 
-### file注册中心和配置中心
+### 第一类：file注册中心和配置中心
 #### Server端
 ```
 registry {
@@ -39,30 +40,37 @@ config {
 }
 ```
 - file、db模式启动server，见文章上方节点：启动Server
-
 #### Client端
 ```
-spring.cloud.alibaba.seata.tx-service-group=my_test_tx_group ---------------> 事务分组配置
-seata.tx-service-group=my_test_tx_group ---------------> 事务分组定义（两种方式等价，二选一）
-
-seata.service.vgroup-mapping.my_test_tx_group=cluster_beijing  ---------------> 指定事务分组至集群映射（等号右侧的集群名需要与Seata服务端配置的cluster保持一致）
-
-# 设置vgroup-mapping（即服务端的cluster）中各个seata-server服务端节点的IP和端口信息
-# 仅在客户端（微服务）配置的seata.registry.type=file才需要使用，不推荐在正式环境使用file类型
-# seata.registry.type=nacos或其他类型时（微服务客户端和seata-server服务端应同时指定为nacos），则无需此参数
-seata.registry.type=file
-seata.service.grouplist.cluster_beijing=127.0.0.1:8091
-
+registry {
+  # file 、nacos 、eureka、redis、zk、consul、etcd3、sofa
+  type = "file"                ---------------> 使用file作为注册中心
+}
+config {
+  # file、nacos 、apollo、zk、consul、etcd3
+  type = "file"                ---------------> 使用file作为配置中心
+  file {
+    name = "file.conf"         ---------------> 配置参数存储文件
+  }
+}
+seata.tx-service-group=my_test_tx_group ---------------> 事务分组配置
+file.conf: 
+    service {
+      vgroupMapping.my_test_tx_group = "default"
+      default.grouplist = "127.0.0.1:8091"
+    }
 ```
 - 读取配置
 > 通过FileConfiguration本地加载file.conf的配置参数
 - 获取事务分组
-> spring配置，springboot可配置在yml、properties中，服务启动时加载配置，对应的值"my_test_tx_group"即为一个事务分组名，若不配置，默认获取属性spring.application.name的值+"-fescar-service-group"  
+> spring配置，springboot可配置在yml、properties中，服务启动时加载配置，对应的值"my_test_tx_group"即为一个事务分组名，若不配置，默认获取属性spring.application.name的值+"-seata-service-group"  
 - 查找TC集群名
 > 拿到事务分组名"my_test_tx_group"拼接成"service.vgroupMapping.my_test_tx_group"查找TC集群名clusterName为"default"
 - 查询TC服务
 > 拼接"service."+clusterName+".grouplist"找到真实TC服务地址127.0.0.1:8091
-### nacos注册中心和配置中心
+
+
+### 第二类：注册中心和配置中心(以nacos为例)
 #### Server端
 ```
 registry {
@@ -95,9 +103,38 @@ txt为参数明细（包含Server和Client），sh为linux脚本，windows可下
 
 #### Client端
 ```
-spring.cloud.alibaba.seata.tx-service-group=my_test_tx_group ---------------> 事务分组定义
-seata.service.vgroup-mapping.my_test_tx_group=cluster_beijing  ---------------> 指定事务分组至集群映射（等号右侧的集群名需要与Seata服务端配置的cluster保持一致）
+spring.cloud.alibaba.seata.tx-service-group=my_test_tx_group ---------------> 事务分组配置
+registry {
+  # file 、nacos 、eureka、redis、zk、consul、etcd3、sofa
+  type = "nacos"                ---------------> 从nacos获取TC服务
+  nacos {
+    serverAddr = "localhost"
+    namespace = ""
+  }
+}
+config {
+  # file、nacos 、apollo、zk、consul、etcd3
+  type = "nacos"                ---------------> 使用nacos作为配置中心
+  nacos {
+    serverAddr = "localhost"
+    namespace = ""
+  }
+}
 ```
+
+#### Client端(SpringBoot)
+```
+spring.cloud.alibaba.seata.tx-service-group=my_test_tx_group ---------------> 事务分组配置
+seata.service.vgroup-mapping.my_test_tx_group=cluster_beijing  ---------------> 指定事务分组至集群映射关系（等号右侧的集群名需要与Seata服务端配置的cluster保持一致）
+
+# 设置vgroup-mapping（即服务端的cluster）中各个seata-server服务端节点的IP和端口信息
+# 仅在客户端（微服务）配置的seata.registry.type=file才需要使用，不推荐在正式环境使用file类型
+# seata.registry.type=nacos或其他类型时（微服务客户端和seata-server服务端应同时指定为nacos），则无需此参数
+seata.registry.type=file
+seata.service.grouplist.cluster_beijing=127.0.0.1:8091
+```
+
+
 - 读取配置
 > 通过NacosConfiguration远程读取seata配置参数
 - 获取事务分组

--- a/docs/zh-cn/user/txgroup/transaction-group.md
+++ b/docs/zh-cn/user/txgroup/transaction-group.md
@@ -57,7 +57,6 @@ config {
 ```
 file.conf
 ```
-file.conf: 
     service {
       vgroupMapping.my_test_tx_group = "default"
       default.grouplist = "127.0.0.1:8091"
@@ -139,11 +138,11 @@ spring.cloud.alibaba.seata.tx-service-group=my_test_tx_group ---------------> �
 seata.service.vgroup-mapping.my_test_tx_group=cluster_beijing  ---------------> 指定事务分组至集群映射关系（等号右侧的集群名需要与Seata服务端配置的cluster保持一致）
 
 seata.registry.type=nacos      ---------------> 使用nacos作为注册中心
-seata.registry.nacos.server-addr=nacos注册中心所在ip:端口
+seata.registry.nacos.server-addr=nacos注册中心IP:端口
 seata.registry.nacos.application=seata-server     ---------------> Seata服务名（应与seata-server实际注册的服务名一致）
 seata.registry.nacos.group=SEATA_GROUP            ---------------> Seata分组名（应与seata-server实际注册的分组名一致）
 ```
->> 另外：若Client不通过Nacos获取seata-server服务信息，而是直接指定seata-server服务端节点的IP和端口信息，则可将以上客户端配置中涉及nacos参数改为以下两个参数：
+>> 另外：若Client不通过Nacos获取seata-server服务信息，而是直接指定seata-server服务端节点的IP和端口信息，则可将以上application.properties中涉及nacos几个配置改为如两个配置：
 >> 
 >> seata.registry.type=file       ----> 不推荐在正式环境使用
 >> 

--- a/docs/zh-cn/user/txgroup/transaction-group.md
+++ b/docs/zh-cn/user/txgroup/transaction-group.md
@@ -69,8 +69,8 @@ seata.tx-service-group=my_test_tx_group ---------------> 事务分组配置（�
 ```
 - 读取配置
  通过FileConfiguration本地加载file.conf的配置参数
-- 获取事务分组
- spring配置，springboot可配置在yml、properties中，服务启动时加载配置，对应的值"my_test_tx_group"即为一个事务分组名，若不配置，默认获取属性spring.application.name的值+"-seata-service-group"  
+- 获取事务分组(服务启动时加载配置)
+ spring/springboot可配置在yml、properties中，对应值"my_test_tx_group"即为事务分组名，若不配置则默认以：spring.application.name值+"-seata-service-group"拼接后的字符串作为分组名
 - 查找TC集群名
  拿到事务分组名"my_test_tx_group"拼接成"service.vgroupMapping.my_test_tx_group"查找TC集群名clusterName为"default"
 - 查询TC服务
@@ -148,7 +148,7 @@ config {
 application.properties
 ```
 seata.tx-service-group=my_test_tx_group ---------------> 事务分组配置（在v1.5之后默认值为default_tx_group）
-seata.service.vgroup-mapping.my_test_tx_group=default  ---------------> 指定事务分组至集群映射关系（等号右侧的集群名需要与Seata-server注册到Nacose的cluster保持一致）
+seata.service.vgroup-mapping.my_test_tx_group=default  ---------------> 指定事务分组至集群映射关系（等号右侧的集群名需要与Seata-server注册到Nacos的cluster保持一致）
 seata.registry.type=nacos      ---------------> 使用nacos作为注册中心
 seata.registry.nacos.server-addr=nacos注册中心IP:端口
 seata.registry.nacos.application=seata-server     ---------------> Seata服务名（应与seata-server实际注册的服务名一致）
@@ -164,8 +164,8 @@ seata.registry.nacos.group=SEATA_GROUP            ---------------> Seata分组�
 
 - 读取配置
  通过NacosConfiguration远程读取seata配置参数
-- 获取事务分组
- springboot可配置在yml、properties中，服务启动时加载配置，对应的值"my_test_tx_group"即为一个事务分组名，若不配置，默认获取属性spring.application.name的值+"-seata-service-group"
+- 获取事务分组(服务启动时加载配置)
+ spring/springboot可配置在yml、properties中，对应值"my_test_tx_group"即为事务分组名，若不配置则默认以：spring.application.name值+"-seata-service-group"拼接后的字符串作为分组名
 - 查找TC集群名
  拿到事务分组名"my_test_tx_group"拼接成"service.vgroupMapping.my_test_tx_group"从配置中心查找到TC集群名clusterName为"default"
 - 查找TC服务

--- a/docs/zh-cn/user/txgroup/transaction-group.md
+++ b/docs/zh-cn/user/txgroup/transaction-group.md
@@ -6,11 +6,13 @@ description: Seata 事务分组。
 
 # 事务分组专题
 
-### 事务分组是什么？
-事务分组是seata的资源逻辑，类似于服务实例。在file.conf中的my_test_tx_group就是一个事务分组。
+### 事务分组涉及的概念？
+- 事务分组：seata的资源逻辑，可以按微服务的需要对事务进行逻辑上分组，每组取一个名字。可以在应用程序（客户端）中通过属性tx-service-group定义事务分组。
+- 集群：seata-server服务端一个或多个节点组成的集群cluster。 应用程序（客户端）使用时需要指定事务逻辑分组与Seata服务端集群的映射关系。
+
 ### 通过事务分组如何找到后端集群？
-1. 首先程序中配置了事务分组（GlobalTransactionScanner 构造方法的txServiceGroup参数）
-2. 程序会通过用户配置的配置中心去寻找service.vgroupMapping
+1. 首先程序中配置了事务分组（GlobalTransactionScanner 构造方法的txServiceGroup参数， 在Spring中配置项为：seata.tx-service-group）
+2. 程序会通过用户配置的配置中心去寻找service.vgroupMapping （在Spring中配置项为：seata.service.vgroup-mapping.事务分组名=集群名， 其中集群名需要与Seata服务端配置的cluster保持一致）
 .[*事务分组配置项*]，取得配置项的值就是TC集群的名称
 3. 拿到集群名称程序通过一定的前后缀+集群名称去构造服务名，各配置中心的服务名实现不同
 4. 拿到服务名去相应的注册中心去拉取相应服务名的服务列表，获得后端真实的TC服务列表
@@ -37,25 +39,20 @@ config {
 }
 ```
 - file、db模式启动server，见文章上方节点：启动Server
+
 #### Client端
 ```
-registry {
-  # file 、nacos 、eureka、redis、zk、consul、etcd3、sofa
-  type = "file"                ---------------> 使用file作为注册中心
-}
-config {
-  # file、nacos 、apollo、zk、consul、etcd3
-  type = "file"                ---------------> 使用file作为配置中心
-  file {
-    name = "file.conf"         ---------------> 配置参数存储文件
-  }
-}
 spring.cloud.alibaba.seata.tx-service-group=my_test_tx_group ---------------> 事务分组配置
-file.conf: 
-    service {
-      vgroupMapping.my_test_tx_group = "default"
-      default.grouplist = "127.0.0.1:8091"
-    }
+seata.tx-service-group=my_test_tx_group ---------------> 事务分组定义（两种方式等价，二选一）
+
+seata.service.vgroup-mapping.my_test_tx_group=cluster_beijing  ---------------> 指定事务分组至集群映射（等号右侧的集群名需要与Seata服务端配置的cluster保持一致）
+
+# 设置vgroup-mapping（即服务端的cluster）中各个seata-server服务端节点的IP和端口信息
+# 仅在客户端（微服务）配置的seata.registry.type=file才需要使用，不推荐在正式环境使用file类型
+# seata.registry.type=nacos或其他类型时（微服务客户端和seata-server服务端应同时指定为nacos），则无需此参数
+seata.registry.type=file
+seata.service.grouplist.cluster_beijing=127.0.0.1:8091
+
 ```
 - 读取配置
 > 通过FileConfiguration本地加载file.conf的配置参数
@@ -98,28 +95,15 @@ txt为参数明细（包含Server和Client），sh为linux脚本，windows可下
 
 #### Client端
 ```
-spring.cloud.alibaba.seata.tx-service-group=my_test_tx_group ---------------> 事务分组配置
-registry {
-  # file 、nacos 、eureka、redis、zk、consul、etcd3、sofa
-  type = "nacos"                ---------------> 从nacos获取TC服务
-  nacos {
-    serverAddr = "localhost"
-    namespace = ""
-  }
-}
-config {
-  # file、nacos 、apollo、zk、consul、etcd3
-  type = "nacos"                ---------------> 使用nacos作为配置中心
-  nacos {
-    serverAddr = "localhost"
-    namespace = ""
-  }
-}
+spring.cloud.alibaba.seata.tx-service-group=my_test_tx_group ---------------> 事务分组定义
+seata.service.vgroup-mapping.my_test_tx_group=cluster_beijing  ---------------> 指定事务分组至集群映射（等号右侧的集群名需要与Seata服务端配置的cluster保持一致）
+
+
 ```
 - 读取配置
 > 通过NacosConfiguration远程读取seata配置参数
 - 获取事务分组
-> springboot可配置在yml、properties中，服务启动时加载配置，对应的值"my_test_tx_group"即为一个事务分组名，若不配置，默认获取属性spring.application.name的值+"-fescar-service-group"
+> springboot可配置在yml、properties中，服务启动时加载配置，对应的值"my_test_tx_group"即为一个事务分组名，若不配置，默认获取属性spring.application.name的值+"-seata-service-group"
 - 查找TC集群名
 > 拿到事务分组名"my_test_tx_group"拼接成"service.vgroupMapping.my_test_tx_group"从配置中心查找到TC集群名clusterName为"default"
 - 查找TC服务

--- a/docs/zh-cn/user/txgroup/transaction-group.md
+++ b/docs/zh-cn/user/txgroup/transaction-group.md
@@ -97,8 +97,6 @@ txt为参数明细（包含Server和Client），sh为linux脚本，windows可下
 ```
 spring.cloud.alibaba.seata.tx-service-group=my_test_tx_group ---------------> 事务分组定义
 seata.service.vgroup-mapping.my_test_tx_group=cluster_beijing  ---------------> 指定事务分组至集群映射（等号右侧的集群名需要与Seata服务端配置的cluster保持一致）
-
-
 ```
 - 读取配置
 > 通过NacosConfiguration远程读取seata配置参数

--- a/docs/zh-cn/user/txgroup/transaction-group.md
+++ b/docs/zh-cn/user/txgroup/transaction-group.md
@@ -21,11 +21,12 @@ description: Seata 事务分组。
 
 ## 事务分组使用案例
 seata注册、配置中心类型分为两大类：
-- 内置file
+- 内置File
 - 第三方注册（配置）中心。如nacos等等，注册中心和配置中心之间没有约束，可各自使用不同具体选型。
 
-### 第一类：内置file
-#### Server端
+### 第一类：内置File
+#### Seata Server端
+registry.conf
 ```
 registry {
   # file 、nacos 、eureka、redis、zk、consul、etcd3、sofa
@@ -39,7 +40,7 @@ config {
   }
 }
 ```
-- file、db模式启动server，见文章上方节点：启动Server
+- file、db模式启动Seata Server，见文章上方节点：启动Seata Server
 #### Client端
 registry.conf
 ```
@@ -64,20 +65,21 @@ file.conf
 ```
 application.properties
 ```
-seata.tx-service-group=my_test_tx_group ---------------> 事务分组配置
+seata.tx-service-group=my_test_tx_group ---------------> 事务分组配置（在v1.5之后默认值为default_tx_group）
 ```
 - 读取配置
-> 通过FileConfiguration本地加载file.conf的配置参数
+ 通过FileConfiguration本地加载file.conf的配置参数
 - 获取事务分组
-> spring配置，springboot可配置在yml、properties中，服务启动时加载配置，对应的值"my_test_tx_group"即为一个事务分组名，若不配置，默认获取属性spring.application.name的值+"-seata-service-group"  
+ spring配置，springboot可配置在yml、properties中，服务启动时加载配置，对应的值"my_test_tx_group"即为一个事务分组名，若不配置，默认获取属性spring.application.name的值+"-seata-service-group"  
 - 查找TC集群名
-> 拿到事务分组名"my_test_tx_group"拼接成"service.vgroupMapping.my_test_tx_group"查找TC集群名clusterName为"default"
+ 拿到事务分组名"my_test_tx_group"拼接成"service.vgroupMapping.my_test_tx_group"查找TC集群名clusterName为"default"
 - 查询TC服务
-> 拼接"service."+clusterName+".grouplist"找到真实TC服务地址127.0.0.1:8091
+ 拼接"service."+clusterName+".grouplist"找到真实TC服务地址127.0.0.1:8091
 
 ----
 ### 第二类：注册中心和配置中心(以nacos为例)
-#### Server端
+#### Seata Server端
+registry.conf
 ```
 registry {
   # file 、nacos 、eureka、redis、zk、consul、etcd3、sofa
@@ -85,7 +87,7 @@ registry {
   nacos {
     application = "seata-server"  ---------------> 指定注册至nacos注册中心的服务名
     group = "SEATA_GROUP"         ---------------> 指定注册至nacos注册中心的分组名
-    serverAddr = "localhost"      ---------------> nacos注册中心所在ip
+    serverAddr = "localhost"      ---------------> nacos注册中心IP:端口
     namespace = ""                ---------------> nacos命名空间id，""为nacos保留public空间控件，用户勿配置namespace = "public"
     cluster = "default"           ---------------> 指定注册至nacos注册中心的集群名
   }
@@ -94,25 +96,36 @@ config {
   # file、nacos 、apollo、zk、consul、etcd3
   type = "nacos"                  ------------> 使用nacos作为配置中心
   nacos {
-    serverAddr = "localhost"      ---------------> nacos配置中心所在ip
+    serverAddr = "localhost"      ---------------> nacos注册中心IP:端口
     namespace = ""
     group = "SEATA_GROUP"         ---------------> nacos配置中心的分组名
-    dataId = "seataServer.properties"  ---------------> nacos配置中心配置ID
+    dataId = "seataServer.properties"  ---------------> nacos配置中心的配置ID
   }
 }
 
 ```
-- 脚本
-> script-->config-center下的3个文件nacos-config.py、nacos-config.sh、config.txt  
-txt为参数明细（包含Server和Client），sh为linux脚本，windows可下载git来操作，py为python脚本。  
-- 导入配置
-> 用命令执行脚本导入seata配置参数至nacos，在nacos控制台查看配置确认是否成功  
-- 注册TC
-> 启动seata-server注册至nacos，查看nacos控制台服务列表确认是否成功  
+- 配置中心配置项
+
+
+  在Seata Server的安装目录conf下README-zh.md或README.md文件中介绍了Seata需要的常见脚本链接，包括三类：客户端的配置和SQL、SeataServer端部署所需SQL和脚本、配置中心的初始化配置项脚本。
+  其中在script/config-center下有文件和目录如下
+     - README.md     使用帮助
+     - config.txt    配置项明细（包含Server和Client）
+     - nacos/        推送至nacos的脚本 
+     - apollo/
+     - consul/
+     - etcd3/
+     - zk/
+  
+  config.txt中的配置项需要根据实际情况选择和修改。
+  然后配置到配置中心：即可参照README.md使用帮助通过脚本推送至配置中心。也将config.txt中的内容人工拷贝至配置中心（例如通过Nacas的Web页面）
+
+- 注册至注册中心
+ 启动seata-server注册至nacos，查看nacos控制台服务列表确认是否成功  
 
 #### Client端
 ```
-spring.cloud.alibaba.seata.tx-service-group=my_test_tx_group ---------------> 事务分组配置
+seata.tx-service-group=my_test_tx_group ---------------> 事务分组配置（在v1.5之后默认值为default_tx_group）
 registry {
   # file 、nacos 、eureka、redis、zk、consul、etcd3、sofa
   type = "nacos"                ---------------> 从nacos获取TC服务
@@ -134,29 +147,28 @@ config {
 #### Client端(SpringBoot)
 application.properties
 ```
-spring.cloud.alibaba.seata.tx-service-group=my_test_tx_group ---------------> 事务分组配置
-seata.service.vgroup-mapping.my_test_tx_group=cluster_beijing  ---------------> 指定事务分组至集群映射关系（等号右侧的集群名需要与Seata服务端配置的cluster保持一致）
-
+seata.tx-service-group=my_test_tx_group ---------------> 事务分组配置（在v1.5之后默认值为default_tx_group）
+seata.service.vgroup-mapping.my_test_tx_group=default  ---------------> 指定事务分组至集群映射关系（等号右侧的集群名需要与Seata-server注册到Nacose的cluster保持一致）
 seata.registry.type=nacos      ---------------> 使用nacos作为注册中心
 seata.registry.nacos.server-addr=nacos注册中心IP:端口
 seata.registry.nacos.application=seata-server     ---------------> Seata服务名（应与seata-server实际注册的服务名一致）
 seata.registry.nacos.group=SEATA_GROUP            ---------------> Seata分组名（应与seata-server实际注册的分组名一致）
 ```
->> 另外：若Client不通过Nacos获取seata-server服务信息，而是直接指定seata-server服务端节点的IP和端口信息，则可将以上application.properties中涉及nacos几个配置改为如两个配置：
->> 
->> seata.registry.type=file       ----> 不推荐在正式环境使用
->> 
->> seata.service.grouplist.cluster_beijing=127.0.0.1:8091    ----> vgroup-mapping（服务端cluster）各个seata-server节点信息
+> 另外：若Client不通过Nacos获取seata-server服务信息，而是直接指定seata-server服务端节点的IP和端口信息，则可将以上application.properties中涉及nacos几个配置改为如两个配置：
+> 
+> seata.registry.type=file       ----> 不推荐在正式环境使用
+> 
+> seata.service.grouplist.cluster_beijing=127.0.0.1:8091    ----> vgroup-mapping（服务端cluster）各个seata-server节点信息
 
 
 
 - 读取配置
-> 通过NacosConfiguration远程读取seata配置参数
+ 通过NacosConfiguration远程读取seata配置参数
 - 获取事务分组
-> springboot可配置在yml、properties中，服务启动时加载配置，对应的值"my_test_tx_group"即为一个事务分组名，若不配置，默认获取属性spring.application.name的值+"-seata-service-group"
+ springboot可配置在yml、properties中，服务启动时加载配置，对应的值"my_test_tx_group"即为一个事务分组名，若不配置，默认获取属性spring.application.name的值+"-seata-service-group"
 - 查找TC集群名
-> 拿到事务分组名"my_test_tx_group"拼接成"service.vgroupMapping.my_test_tx_group"从配置中心查找到TC集群名clusterName为"default"
+ 拿到事务分组名"my_test_tx_group"拼接成"service.vgroupMapping.my_test_tx_group"从配置中心查找到TC集群名clusterName为"default"
 - 查找TC服务
-> 根据serverAddr和namespace以及clusterName在注册中心找到真实TC服务列表
+ 根据serverAddr和namespace以及clusterName在注册中心找到真实TC服务列表
 
 注：serverAddr和namespace与Server端一致，clusterName与Server端cluster一致

--- a/docs/zh-cn/user/txgroup/transaction-group.md
+++ b/docs/zh-cn/user/txgroup/transaction-group.md
@@ -7,7 +7,7 @@ description: Seata 事务分组。
 # 事务分组专题
 
 ### 事务分组是什么？
-- 事务分组：seata的资源逻辑，可以按微服务的需要对事务进行逻辑上分组，每组取一个名字。可以在应用程序（客户端）中通过属性tx-service-group定义事务分组。
+- 事务分组：seata的资源逻辑，可以按微服务的需要，在应用程序（客户端）对自行定义事务分组，每组取一个名字。
 - 集群：seata-server服务端一个或多个节点组成的集群cluster。 应用程序（客户端）使用时需要指定事务逻辑分组与Seata服务端集群的映射关系。
 ### 事务分组如何找到后端Seata集群？
 1. 首先应用程序（客户端）中配置了事务分组（GlobalTransactionScanner 构造方法的txServiceGroup参数）。若应用程序是SpringBoot则通过seata.tx-service-group 配置


### PR DESCRIPTION
完善了官网文档：
1、Seata介绍（增加了github中README.md中图，这么好的图不放在官网文档中，多可惜）
2、Seata事务分组：对说明解释进行了调整完善，避免了歧义。  纠正了“-fescar-service-group”等错误内容。按实际补充了seata-server使用nacos注册中心和配置中心的描述，完善了nacos配置项获取及注入方式的说明
3、原文档中seata-server.sh启动选择中-h解释有误的描述进行了修正。