### PR TITLE
docs: update sample usage in quickstart of current and 2.0

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/user/quickstart.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/user/quickstart.md
@@ -217,11 +217,4 @@ sh seata-server.sh -p 8091 -h 127.0.0.1 -m file
 
 ### Step 5: Run example
 
-Go to samples repo: [seata-samples](https://github.com/apache/incubator-seata-samples)
-
-- Start DubboAccountServiceStarter
-- Start DubboStorageServiceStarter
-- Start DubboOrderServiceStarter
-- Run DubboBusinessTester for demo test
-
-TBD: scripts for run demo applications
+Go to samples repo: [seata-samples/at-samples](https://github.com/apache/incubator-seata-samples/tree/master/at-sample), and find a suitable dependency setup. Start `Account`, `Storage`, `Order`, `Business` services accordingly.

--- a/i18n/en/docusaurus-plugin-content-docs/version-v2.0/user/quickstart.md
+++ b/i18n/en/docusaurus-plugin-content-docs/version-v2.0/user/quickstart.md
@@ -217,11 +217,4 @@ sh seata-server.sh -p 8091 -h 127.0.0.1 -m file
 
 ### Step 5: Run example
 
-Go to samples repo: [seata-samples](https://github.com/apache/incubator-seata-samples)
-
-- Start DubboAccountServiceStarter
-- Start DubboStorageServiceStarter
-- Start DubboOrderServiceStarter
-- Run DubboBusinessTester for demo test
-
-TBD: scripts for run demo applications
+Go to samples repo: [seata-samples/at-samples](https://github.com/apache/incubator-seata-samples/tree/master/at-sample), and find a suitable dependency setup. Start `Account`, `Storage`, `Order`, `Business` services accordingly.

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/user/quickstart.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/user/quickstart.md
@@ -215,11 +215,4 @@ sh seata-server.sh -p 8091 -h 127.0.0.1 -m file
 
 ### 步骤 5: 运行示例
 
-示例仓库: [seata-samples](https://github.com/apache/incubator-seata-samples)
-
-- 启动 DubboAccountServiceStarter
-- 启动 DubboStorageServiceStarter
-- 启动 DubboOrderServiceStarter
-- 运行 DubboBusinessTester for demo test
-
-TBD: 运行演示应用程序的脚本
+示例仓库: [seata-samples/at-samples](https://github.com/apache/incubator-seata-samples/tree/master/at-sample)。找到合适的依赖项设置，按顺序启动 `Account`, `Storage`, `Order`, `Business` 服务。

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/version-v2.0/user/quickstart.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/version-v2.0/user/quickstart.md
@@ -214,11 +214,4 @@ sh seata-server.sh -p 8091 -h 127.0.0.1 -m file
 
 ### 步骤 5: 运行示例
 
-示例仓库: [seata-samples](https://github.com/apache/incubator-seata-samples)
-
-- 启动 DubboAccountServiceStarter
-- 启动 DubboStorageServiceStarter
-- 启动 DubboOrderServiceStarter
-- 运行 DubboBusinessTester for demo test
-
-TBD: 运行演示应用程序的脚本
+示例仓库: [seata-samples/at-samples](https://github.com/apache/incubator-seata-samples/tree/master/at-sample)。找到合适的依赖项设置，按顺序启动 `Account`, `Storage`, `Order`, `Business` 服务。


### PR DESCRIPTION
## What is the purpose of the change

Fixes apache/incubator-seata-samples#648.
Since seata-samples has been refactored, the usage of samples should be updated.

## Brief changelog

**Step 5: Run example**

Go to samples repo: [seata-samples/at-samples](https://github.com/apache/incubator-seata-samples/tree/master/at-sample), and find a suitable dependency setup. Start `Account`, `Storage`, `Order`, `Business` services accordingly.

---

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-seata-website/issues) filed for the change(usually before you start working on it).  Trivial changes such as typos do not necessitate a GITHUB issue. Your pull request should solely focus on addressing this specific issue without incorporating any other modifications. Each PR should resolve a single issue.
- [x] Format the pull request title like `doc: add an operations guide document`. Each commit within the pull request should contain a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Test your code locally by running `npm run build`, and make sure it works as expected.
- [x] Ensure that no files under the `build` folder are included in the commit, as well as the `package-lock.json` and `yarn.lock` files.
