### PR TITLE
Update deployment documentation

### DIFF
--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/ops/deploy-by-docker-compose.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/ops/deploy-by-docker-compose.md
@@ -493,6 +493,3 @@ seata-server 支持以下环境变量：
 
 > 可选, 指定 seata-server 运行环境, 如 `dev`, `test` 等, 服务启动时会使用 `registry-dev.conf` 这样的配置
 
-- **SEATA_CONFIG_NAME**
-
-> 可选, 指定配置文件位置, 如 `file:/root/registry`, 将会加载 `/root/registry.conf` 作为配置文件，如果需要同时指定 `file.conf`文件，需要将`registry.conf`的`config.file.name`的值改为类似`file:/root/file.conf`：

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/ops/deploy-by-docker.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/ops/deploy-by-docker.md
@@ -116,8 +116,3 @@ seata-server 支持以下环境变量：
 - **SEATA_ENV**
 
 > 可选, 指定 seata-server 运行环境, 如 `dev`, `test` 等, 服务启动时会使用 `registry-dev.conf` 这样的配置
-
-- **SEATA_CONFIG_NAME**
-
-> 可选, 指定配置文件位置, 如 `file:/root/registry`, 将会加载 `/root/registry.conf` 作为配置文件，如果需要同时指定 `file.conf`文件，需要将`registry.conf`的`config.file.name`的值改为类似`file:/root/file.conf`：
-

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/ops/deploy-by-helm.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/ops/deploy-by-helm.md
@@ -14,7 +14,8 @@ date: 2019-12-01
 
 
 ```bash
-$ cd ./script/server/helm/seata-server
+$ git clone https://github.com/apache/incubator-seata.git
+$ cd ./incubator-seata/script/server/helm/seata-server
 $ helm install seata-server ./seata-server
 ```
 
@@ -52,12 +53,12 @@ env:
   seataPort: "8091"
   storeMode: "file"
   seataIp: "127.0.0.1"
-  seataConfigName: "file:/root/seata-config/registry"
 
 volume:
   - name: seata-config
-    mountPath: /root/seata-config
-    hostPath: /root/workspace/seata/seata-config/file
+    mountPath: /seata-server/resources/application.yml
+    subPath: application.yml
+    hostPath: /root/workspace/seata/seata-config/application.yml
 ```
 
 

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/ops/deploy-by-helm.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/ops/deploy-by-helm.md
@@ -31,8 +31,7 @@ $ helm install seata-server ./seata-server
 
 ### 使用自定义配置文件
 
-指定配置文件可以通过挂载的方式实现，如将`/root/workspace/seata/seata-config/file`  下的配置文件挂载到 pod 中，挂载后需要通过指定 `SEATA_CONFIG_NAME` 指定配置文件位置，并且环境变量的值需要以`file:`开始, 如: `file:/root/seata-config/registry`
-
+指定配置文件可以通过挂载的方式实现，如将`/root/workspace/seata/seata-config/application.yml`下的配置文件挂载到 pod 中的`/seata-server/resources/application.yml`覆盖项目原有配置文件。
 - Values.yaml
 
 ```yaml

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/user/configuration/nacos.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/user/configuration/nacos.md
@@ -51,20 +51,20 @@ seata:
 
 ### Server 端配置中心
 
-在 [registry.conf](https://github.com/apache/incubator-seata/blob/develop/script/server/config/registry.conf) 中加入对应配置中心,其余[配置参考](https://github.com/apache/incubator-seata/tree/develop/script/server)
+在 `conf/application.yaml`加入以下配置, 其余配置参考 [configuration options](https://github.com/apache/incubator-seata/blob/2.x/server/src/main/resources/application.example.yml):
 
-```
-config {
-  type = "nacos"
-
-  nacos {
-    serverAddr = "127.0.0.1:8848"
-    group = "SEATA_GROUP"
-    namespace = ""
-    username = "nacos"
-    password = "nacos"
-  }
-}
+```yaml
+seata:
+  config:
+    type: nacos
+    nacos:
+      server-addr: 127.0.0.1:8848
+      namespace:
+      group: SEATA_GROUP
+      context-path:
+      username: nacos
+      password: nacos
+      data-id: seataServer.properties
 
 ```
 


### PR DESCRIPTION
## What is the purpose of the change

Update deployment documentation

## Brief changelog

Removed variables that are no longer used in docker deployment documentation and are prone to ambiguity.
Update the Heml deployment document to adapt to the new version of seata.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-seata-website/issues) filed for the change(usually before you start working on it).  Trivial changes such as typos do not necessitate a GITHUB issue. Your pull request should solely focus on addressing this specific issue without incorporating any other modifications. Each PR should resolve a single issue.
- [ ] Format the pull request title like `doc: add an operations guide document`. Each commit within the pull request should contain a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Test your code locally by running `npm run build`, and make sure it works as expected.
- [ ] Ensure that no files under the `build` folder are included in the commit, as well as the `package-lock.json` and `yarn.lock` files.
