### PR TITLE
doc: fix typo in saga.md (Correct typos in inventory operations in the Saga mode documentation)

### DIFF
--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/user/mode/saga.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/user/mode/saga.md
@@ -966,7 +966,7 @@ StateMachineInstance inst = stateMachineEngine.start(stateMachineName, null, par
 Seata 会把一个 Saga注解化 接口当成一个 Resource，也叫 Saga annotation Resource。在业务接口中核心的注解是 `@CompensationBusinessAction`
 
 - action 阶段，执行一阶段的业务逻辑
-- compensation 阶段，当事务觉一回滚（Rollback） 这一阶段使用 `compensationMethod` 属性所指向的方法，来执行自定义 补偿 的工作。
+- compensation 阶段，当事务决定回滚（Rollback）， 这一阶段使用 `compensationMethod` 属性所指向的方法，来执行自定义 补偿 的工作。
 
 其次，可以在 Saga 模式下使用 `BusinessActionContext` 在事务上下文中传递查询参数。如下属性：
 

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/version-v2.5/user/mode/saga.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/version-v2.5/user/mode/saga.md
@@ -966,7 +966,7 @@ StateMachineInstance inst = stateMachineEngine.start(stateMachineName, null, par
 Seata 会把一个 Saga注解化 接口当成一个 Resource，也叫 Saga annotation Resource。在业务接口中核心的注解是 `@CompensationBusinessAction`
 
 - action 阶段，执行一阶段的业务逻辑
-- compensation 阶段，当事务觉一回滚（Rollback） 这一阶段使用 `compensationMethod` 属性所指向的方法，来执行自定义 补偿 的工作。
+- compensation 阶段，当事务决定回滚（Rollback），这一阶段使用 `compensationMethod` 属性所指向的方法，来执行自定义 补偿 的工作。
 
 其次，可以在 Saga 模式下使用 `BusinessActionContext` 在事务上下文中传递查询参数。如下属性：
 


### PR DESCRIPTION
## What is this PR for?
Fix a trivial typo in the Saga mode documentation (docs/saga.md):
Corrected the wrong word 
**"当事务觉一回滚（Rollback） 这一阶段使用"**  to **"当事务决定回滚（Rollback），这一阶段使用"**  

## How did you implement your fix?
1. Modified only the typo in `docs/saga.md` (no other format/line changes).
2. Tested local build with `npm run build` (no errors).

## Does this PR introduce any breaking changes?
- [ ] Yes (please describe)
- ✅ No