### PR TITLE
docs: add namingserver registry documentation

### DIFF
--- a/docs/user/registry/namingserver.md
+++ b/docs/user/registry/namingserver.md
@@ -1,1 +1,27 @@
-Placeholder. DO NOT DELETE.
+---
+title: Seata Namingserver Registry
+keywords: [Seata, Namingserver, Registry]
+description: Use Seata Namingserver as the registry center.
+---
+
+# Namingserver Registry
+
+Namingserver is Seata's native registry center. It maintains the mapping between transaction groups and Seata server clusters, and helps Seata clients discover available Seata server nodes.
+
+:::caution
+Namingserver is currently a beta feature. Please evaluate it carefully before using it in production, and do not expose the service directly to the public network.
+:::
+
+## Start Namingserver
+
+You can start Namingserver from a binary package or by using the Docker image.
+
+### Start from Binary Package
+
+Download and extract the Seata binary package, then enter the `seata-namingserver` directory.
+
+For macOS or Linux:
+
+```shell
+bin/seata-namingserver.sh
+


### PR DESCRIPTION
## What is this PR?

This PR adds basic English documentation for using Seata Namingserver as a registry center.

## Changes

- Add an overview of Seata Namingserver.
- Add binary package startup instructions.
- Add Docker pull and run examples.
- Add a Docker Compose example.
- Add common Docker environment variables.
- Add basic Seata client and server registry configuration examples.
- Add token retrieval and transaction group mapping examples.

## Why this change?

The current English documentation page for Namingserver is a placeholder. This update provides basic usage instructions for users who want to use Namingserver as the registry center.

Related to apache/incubator-seata#7515

## Checklist

- [x] Documentation has been added or updated.
- [x] The change is limited to documentation.
- [x] No source code behavior is changed.
