### PR TITLE
docs: fix typos in English documentation

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/developers/committer-guide/label-an-issue-guide_dev.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/developers/committer-guide/label-an-issue-guide_dev.md
@@ -15,7 +15,7 @@ Some frequently used labels:
   * help wanted
   * good first issue
 
-* Prority
+* Priority
   * priority/blocker
   * priority/high
   * priority/low

--- a/i18n/en/docusaurus-plugin-content-docs/current/developers/contributor-guide/reporting-security-issues_dev.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/developers/contributor-guide/reporting-security-issues_dev.md
@@ -22,4 +22,4 @@ An overview of the vulnerability handling process is:
 * The reporter reports the vulnerability privately to Apache.
 * The appropriate project's security team works privately with the reporter to resolve the vulnerability.
 * A new release of the Apache product concerned is made that includes the fix.
-* The vulnerability is publically announced.
+* The vulnerability is publicly announced.

--- a/i18n/en/docusaurus-plugin-content-docs/current/ops/deploy-server.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/ops/deploy-server.md
@@ -30,11 +30,11 @@ bin\seata-server.bat
 
 |Argument|Fullname|Effect|Comment|
 |:--|:--|:--|:--|
-|-h|--host|Specify IP in registry center|Suggest to specify Virtural machine or cloud server, or will use internal IP|
+|-h|--host|Specify IP in registry center|Suggest to specify Virtual machine or cloud server, or will use internal IP|
 |-p|--port|Specify startup port |default is 8091|
 |-m|--storeMode|The way to save transaction log | Support `file` and `db`default is  `file`|
 |-n|--serverNode|Specify the seata-server node ID |Like `1`,`2`,`3`..., default is `1`|
-|-e|--seataEnv|Specify the environment of  seata-server |Like `dev`, `test` etc. Then will use file like `registry-dev.conf` as configuraiton|
+|-e|--seataEnv|Specify the environment of  seata-server |Like `dev`, `test` etc. Then will use file like `registry-dev.conf` as configuration|
 
 For example：
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/overview/faq.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/overview/faq.md
@@ -36,7 +36,7 @@ description: Seata FAQ.
 <a href="#10" target="_self">10. Why didn't my mybatis operation return auto-generated ID? </a>
 <br/>
 
-<a href="#11" target="_self">11.I can't find this package:io.seata.codec.protobuf.generated,and cant't run seata server?</a>
+<a href="#11" target="_self">11.I can't find this package:io.seata.codec.protobuf.generated,and can't run seata server?</a>
 <br/>
 
 <a href="#12" target="_self">12.How does TC use database drivers such as mysql/oracle?</a>
@@ -296,12 +296,12 @@ when the undolog serialization is configured as Jackson, the Jackson version nee
 <h3 id='10'>Q: 10. Why didn't my mybatis operation return auto-generated ID? </h3>
 
 **A:**
-plan1.You should update the configuraton of `mybatis`: set annotation `@Options(useGeneratedKeys = true, keyProperty = "id")` or set the value of useGeneratedKeys and keyProperty in `mybatis` xml configuraton
+plan1.You should update the configuration of `mybatis`: set annotation `@Options(useGeneratedKeys = true, keyProperty = "id")` or set the value of useGeneratedKeys and keyProperty in `mybatis` xml configuration
 plan2.Delete the id field of the undo_log table
 
 ---
 
-<h3 id='11'>Q: 11.I can't find this package:io.seata.codec.protobuf.generated,and cant't run seata server?</h3>
+<h3 id='11'>Q: 11.I can't find this package:io.seata.codec.protobuf.generated,and can't run seata server?</h3>
 
 **A:**
 You can execute this command: `./mvnw clean install -DskipTests=true` (Mac,Linux) or `mvnw.cmd clean install -DskipTests=true`, (Win)[reference issues/2438](https://github.com/apache/incubator-seata/issues/2438),These codes have been removed in version 0.8.1.

--- a/i18n/en/docusaurus-plugin-content-docs/current/user/api.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/user/api.md
@@ -6,7 +6,7 @@ description: Api Guide.
 
 # 1. Overview
 
-Seata API is devided into 2 categories: High-Level API and Low-Level API
+Seata API is divided into 2 categories: High-Level API and Low-Level API
 
 - **High-Level API** : Used for defining and controlling transaction boundary, and querying transaction status.
 - **Low-Level API** : Used for controlling the propagation of transaction context.

--- a/i18n/en/docusaurus-plugin-content-docs/current/user/mode/saga.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/user/mode/saga.md
@@ -285,7 +285,7 @@ So, it is necessary to check whether the current business key already exists in 
 > When the status of a previous branch transaction has not yet been reported, and the next branch transaction has already been registered, it can be assumed that the previous one was actually successful.
 
 
-## API referance
+## API reference
 
 #### StateMachineEngine API
 ``` java
@@ -946,7 +946,7 @@ After defining the Saga annotation interface, we can start a distributed transac
 ```java
 @GlobalTransactional
 public String doTransactionCommit(){
-   sagabean.exectue(actionContext....)
+   sagabean.execute(actionContext....)
 }
 ```
 


### PR DESCRIPTION
## Summary

Fixed 10 spelling errors in the current English documentation.

## Changes

- `user/api.md`: devided → divided
- `user/mode/saga.md`: referance → reference, exectue → execute
- `ops/deploy-server.md`: Virtural → Virtual, configuraiton → configuration
- `overview/faq.md`: cant't → can't (x2), configuraton → configuration (x2)
- `developers/contributor-guide/reporting-security-issues_dev.md`: publically → publicly
- `developers/committer-guide/label-an-issue-guide_dev.md`: Prority → Priority

These are documentation-only spelling fixes and do not change any behavior.